### PR TITLE
fix: PIE deadlock, Python wrapper indent error, and unsafe GCFix/pie deadlock and python bugs

### DIFF
--- a/Source/YesUeMcp/Private/Tools/McpToolRegistry.cpp
+++ b/Source/YesUeMcp/Private/Tools/McpToolRegistry.cpp
@@ -135,12 +135,33 @@ int32 FMcpToolRegistry::GetToolCount() const
 	return ToolClasses.Num();
 }
 
+bool FMcpToolRegistry::DoesToolRequireGameThread(const FString& ToolName) const
+{
+	FScopeLock ScopeLock(&Lock);
+
+	UClass* const* ToolClassPtr = ToolClasses.Find(ToolName);
+	if (!ToolClassPtr || !*ToolClassPtr)
+	{
+		// 未知工具默认需要 GameThread（安全起见）
+		return true;
+	}
+
+	UMcpToolBase* CDO = (*ToolClassPtr)->GetDefaultObject<UMcpToolBase>();
+	if (!CDO)
+	{
+		return true;
+	}
+
+	return CDO->RequiresGameThread();
+}
+
 FMcpToolResult FMcpToolRegistry::ExecuteTool(
 	const FString& ToolName,
 	const TSharedPtr<FJsonObject>& Arguments,
 	const FMcpToolContext& Context)
 {
-	UE_LOG(LogYesUeMcp, Log, TEXT("Executing tool: %s"), *ToolName);
+	UE_LOG(LogYesUeMcp, Log, TEXT("Executing tool: %s (Thread: %s)"),
+		*ToolName, IsInGameThread() ? TEXT("GameThread") : TEXT("Background"));
 
 	UMcpToolBase* Tool = FindTool(ToolName);
 	if (!Tool)

--- a/Source/YesUeMcp/Public/Tools/McpToolRegistry.h
+++ b/Source/YesUeMcp/Public/Tools/McpToolRegistry.h
@@ -51,6 +51,9 @@ public:
 	/** Check if tool exists */
 	bool HasTool(const FString& ToolName) const;
 
+	/** 检查工具是否需要在 GameThread 上执行 */
+	bool DoesToolRequireGameThread(const FString& ToolName) const;
+
 	/** Get number of registered tools */
 	int32 GetToolCount() const;
 

--- a/Source/YesUeMcpEditor/Private/Server/McpServer.cpp
+++ b/Source/YesUeMcpEditor/Private/Server/McpServer.cpp
@@ -241,7 +241,6 @@ bool FMcpServer::HandleMcpRequest(const FHttpServerRequest& Request, const FHttp
 		return true;
 	}
 
-	// Process on game thread for UE API access
 	FMcpRequest McpRequest = ParsedRequest.GetValue();
 
 	// Track pending requests
@@ -252,7 +251,22 @@ bool FMcpServer::HandleMcpRequest(const FHttpServerRequest& Request, const FHttp
 		UE_LOG(LogYesUeMcp, Warning, TEXT("MCP Server overloaded: %d pending requests"), CurrentPending);
 	}
 
-	AsyncTask(ENamedThreads::GameThread, [this, McpRequest, OnComplete]()
+	// 判断是否需要在 GameThread 上执行：
+	// - 工具调用：检查工具的 RequiresGameThread() 标志
+	// - 协议请求（Initialize/ToolsList/Shutdown 等）：始终在 GameThread 上执行
+	bool bNeedsGameThread = true;
+	if (McpRequest.ParsedMethod == EMcpMethod::ToolsCall && McpRequest.Params.IsValid())
+	{
+		FString ToolName;
+		if (McpRequest.Params->TryGetStringField(TEXT("name"), ToolName))
+		{
+			bNeedsGameThread = FMcpToolRegistry::Get().DoesToolRequireGameThread(ToolName);
+			UE_LOG(LogYesUeMcpEditor, Log, TEXT("  Tool '%s' RequiresGameThread=%d"), *ToolName, bNeedsGameThread);
+		}
+	}
+
+	// 通用的请求处理 Lambda（在 GameThread 或后台线程中执行）
+	auto ProcessAndRespond = [this, McpRequest, OnComplete]()
 	{
 		FMcpResponse Response;
 
@@ -296,7 +310,18 @@ bool FMcpServer::HandleMcpRequest(const FHttpServerRequest& Request, const FHttp
 		}
 
 		SendResponse(OnComplete, Response);
-	});
+	};
+
+	if (bNeedsGameThread)
+	{
+		// 需要 GameThread 的请求（大多数工具 + 协议请求）
+		AsyncTask(ENamedThreads::GameThread, MoveTemp(ProcessAndRespond));
+	}
+	else
+	{
+		// 不需要 GameThread 的工具，在后台线程池执行，减轻 GameThread 压力
+		AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask, MoveTemp(ProcessAndRespond));
+	}
 
 	return true;
 }

--- a/Source/YesUeMcpEditor/Private/Tools/Asset/GetAssetDiffTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Asset/GetAssetDiffTool.cpp
@@ -295,7 +295,22 @@ bool UGetAssetDiffTool::ExtractGitBaseVersion(const FString& FilePath, const FSt
 
 	if (ProcHandle.IsValid())
 	{
-		FPlatformProcess::WaitForProc(ProcHandle);
+		// 带超时的非阻塞等待，避免在 GameThread 上无限阻塞
+		const double TimeoutSeconds = 30.0;
+		const double StartTime = FPlatformTime::Seconds();
+		while (FPlatformProcess::IsProcRunning(ProcHandle))
+		{
+			if (FPlatformTime::Seconds() - StartTime > TimeoutSeconds)
+			{
+				FPlatformProcess::TerminateProc(ProcHandle, true);
+				FPlatformProcess::CloseProc(ProcHandle);
+				FPlatformProcess::ClosePipe(PipeRead, PipeWrite);
+				OutError = FString::Printf(TEXT("Git process timed out after %.0f seconds"), TimeoutSeconds);
+				return false;
+			}
+			// 短暂让出 CPU，避免忙等占用 GameThread
+			FPlatformProcess::Sleep(0.01f);
+		}
 		FPlatformProcess::GetProcReturnCode(ProcHandle, &ReturnCode);
 		StdErr = FPlatformProcess::ReadPipe(PipeRead);
 		FPlatformProcess::CloseProc(ProcHandle);
@@ -366,7 +381,43 @@ bool UGetAssetDiffTool::ExtractPerforceBaseVersion(const FString& FilePath, cons
 	FString P4Exe = TEXT("p4.exe");
 	FString P4Args = FString::Printf(TEXT("print -o \"%s\" \"%s\""), *OutTempPath, *FileSpec);
 
-	FPlatformProcess::ExecProcess(*P4Exe, *P4Args, &ReturnCode, &StdOut, &StdErr);
+	{
+		void* PipeRead = nullptr;
+		void* PipeWrite = nullptr;
+		FPlatformProcess::CreatePipe(PipeRead, PipeWrite);
+
+		FProcHandle ProcHandle = FPlatformProcess::CreateProc(
+			*P4Exe, *P4Args, false, true, true, nullptr, 0, nullptr, PipeWrite);
+
+		if (ProcHandle.IsValid())
+		{
+			// 带超时的非阻塞等待，避免在 GameThread 上无限阻塞
+			const double TimeoutSeconds = 60.0;
+			const double StartTime = FPlatformTime::Seconds();
+			while (FPlatformProcess::IsProcRunning(ProcHandle))
+			{
+				if (FPlatformTime::Seconds() - StartTime > TimeoutSeconds)
+				{
+					FPlatformProcess::TerminateProc(ProcHandle, true);
+					FPlatformProcess::CloseProc(ProcHandle);
+					FPlatformProcess::ClosePipe(PipeRead, PipeWrite);
+					OutError = FString::Printf(TEXT("Perforce process timed out after %.0f seconds"), TimeoutSeconds);
+					return false;
+				}
+				FPlatformProcess::Sleep(0.01f);
+			}
+			FPlatformProcess::GetProcReturnCode(ProcHandle, &ReturnCode);
+			StdErr = FPlatformProcess::ReadPipe(PipeRead);
+			FPlatformProcess::CloseProc(ProcHandle);
+		}
+		else
+		{
+			ReturnCode = -1;
+			StdErr = TEXT("Failed to create Perforce process");
+		}
+
+		FPlatformProcess::ClosePipe(PipeRead, PipeWrite);
+	}
 #else
 	FString P4Command = FString::Printf(TEXT("p4 print -o \"%s\" \"%s\""), *OutTempPath, *FileSpec);
 	FPlatformProcess::ExecProcess(TEXT("/bin/sh"), *FString::Printf(TEXT("-c \"%s\""), *P4Command), &ReturnCode, &StdOut, &StdErr);

--- a/Source/YesUeMcpEditor/Private/Tools/Blueprint/QueryBlueprintTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Blueprint/QueryBlueprintTool.cpp
@@ -724,17 +724,17 @@ TSharedPtr<FJsonObject> UQueryBlueprintTool::ExtractComponentOverrides(UBlueprin
 	UInheritableComponentHandler* ICH = Blueprint->GetInheritableComponentHandler(false);
 	if (ICH)
 	{
-		TArray<FComponentKey> OverrideKeys;
-		ICH->GetAllTemplates(OverrideKeys);
+		TArray<UActorComponent*> OverrideTemplates;
+		ICH->GetAllTemplates(OverrideTemplates);
 
-		for (const FComponentKey& Key : OverrideKeys)
+		for (UActorComponent* OverrideTemplate : OverrideTemplates)
 		{
-			UActorComponent* OverrideTemplate = ICH->GetOverridenComponentTemplate(Key);
 			if (!OverrideTemplate)
 			{
 				continue;
 			}
 
+			FComponentKey Key = ICH->FindKey(OverrideTemplate);
 			FString ComponentName = Key.GetSCSVariableName().ToString();
 			if (ComponentName.IsEmpty())
 			{

--- a/Source/YesUeMcpEditor/Private/Tools/Build/TriggerLiveCodingTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Build/TriggerLiveCodingTool.cpp
@@ -13,7 +13,7 @@
 
 FString UTriggerLiveCodingTool::GetToolDescription() const
 {
-	return TEXT("Trigger Live Coding compilation for C++ code changes. Supports synchronous mode with wait_for_completion. Windows only.");
+	return TEXT("Trigger Live Coding compilation for C++ code changes. Use 'wait_for_completion' to query compilation status after triggering. Windows only.");
 }
 
 TMap<FString, FMcpSchemaProperty> UTriggerLiveCodingTool::GetInputSchema() const
@@ -22,7 +22,7 @@ TMap<FString, FMcpSchemaProperty> UTriggerLiveCodingTool::GetInputSchema() const
 
 	FMcpSchemaProperty WaitForCompletion;
 	WaitForCompletion.Type = TEXT("boolean");
-	WaitForCompletion.Description = TEXT("Wait for compilation to complete before returning (default: false, async mode)");
+	WaitForCompletion.Description = TEXT("If true, query current compilation status instead of triggering a new compile (default: false, trigger mode)");
 	WaitForCompletion.bRequired = false;
 	Schema.Add(TEXT("wait_for_completion"), WaitForCompletion);
 
@@ -35,7 +35,7 @@ FMcpToolResult UTriggerLiveCodingTool::Execute(
 {
 	bool bWaitForCompletion = GetBoolArgOrDefault(Arguments, TEXT("wait_for_completion"), false);
 
-	UE_LOG(LogYesUeMcp, Log, TEXT("trigger-live-coding: Triggering Live Coding compilation (wait=%d)"),
+	UE_LOG(LogYesUeMcp, Log, TEXT("trigger-live-coding: Triggering Live Coding compilation (query_status=%d)"),
 		bWaitForCompletion);
 
 #if !PLATFORM_WINDOWS
@@ -70,59 +70,30 @@ FMcpToolResult UTriggerLiveCodingTool::Execute(
 
 	if (bWaitForCompletion)
 	{
-		// Synchronous mode: Wait for compilation to complete
-		return ExecuteSynchronous(LiveCodingModule);
+		// 查询模式：检查当前编译状态（非阻塞）
+		return QueryCompilationStatus(LiveCodingModule);
 	}
 	else
 	{
-		// Asynchronous mode: Just trigger and return immediately
+		// 触发模式：fire-and-forget，立即返回
 		return ExecuteAsynchronous(LiveCodingModule);
 	}
 #endif
 }
 
 #if PLATFORM_WINDOWS
-FMcpToolResult UTriggerLiveCodingTool::ExecuteSynchronous(ILiveCodingModule* LiveCodingModule)
+FMcpToolResult UTriggerLiveCodingTool::QueryCompilationStatus(ILiveCodingModule* LiveCodingModule)
 {
-	UE_LOG(LogYesUeMcp, Log, TEXT("trigger-live-coding: Starting synchronous compilation..."));
+	UE_LOG(LogYesUeMcp, Log, TEXT("trigger-live-coding: Querying compilation status (non-blocking)..."));
 
-	// Record start time for log filtering
-	const FDateTime CompilationStartTime = FDateTime::Now();
-	const double StartTime = FPlatformTime::Seconds();
-
-	// Use WaitForCompletion flag - this blocks until compilation finishes
-	ELiveCodingCompileResult CompileResult;
-	bool bStarted = LiveCodingModule->Compile(ELiveCodingCompileFlags::WaitForCompletion, &CompileResult);
-
-	const double CompilationTime = FPlatformTime::Seconds() - StartTime;
-
-	// Check Output Log for compilation errors (fallback verification)
-	// The UE API may not always return Failure status even when compilation fails
-	TArray<FMcpLogEntry> RecentErrors = FMcpLogCapture::Get().GetLogs(
-		TEXT("LogLiveCoding"),
-		ELogVerbosity::Error,
-		20,  // Limit
-		TEXT("")  // No search filter
-	);
-
-	// Filter to only entries after compilation started
-	TArray<FString> CompilationErrors;
-	for (const FMcpLogEntry& Entry : RecentErrors)
-	{
-		if (Entry.Timestamp >= CompilationStartTime)
-		{
-			CompilationErrors.Add(Entry.Message);
-		}
-	}
-
-	const bool bHasLogErrors = CompilationErrors.Num() > 0;
-
-	// Build result based on CompileResult
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
-	Result->SetNumberField(TEXT("compilation_time_seconds"), CompilationTime);
 	Result->SetStringField(TEXT("shortcut"), TEXT("Ctrl+Alt+F11"));
 
-	// Map ELiveCodingCompileResult to response
+	// 使用非阻塞方式查询编译状态
+	// Compile with None flag 会立即返回当前状态
+	ELiveCodingCompileResult CompileResult;
+	bool bStarted = LiveCodingModule->Compile(ELiveCodingCompileFlags::None, &CompileResult);
+
 	FString StatusStr;
 	FString MessageStr;
 	bool bSuccess = false;
@@ -130,64 +101,51 @@ FMcpToolResult UTriggerLiveCodingTool::ExecuteSynchronous(ILiveCodingModule* Liv
 	switch (CompileResult)
 	{
 	case ELiveCodingCompileResult::Success:
-		if (bHasLogErrors)
-		{
-			// Override: API said success but logs show errors
-			bSuccess = false;
-			StatusStr = TEXT("failed");
-			MessageStr = FString::Printf(TEXT("Live Coding reported success but errors found in log (%d errors)"), CompilationErrors.Num());
-			UE_LOG(LogYesUeMcp, Warning, TEXT("trigger-live-coding: API reported success but found %d errors in log"), CompilationErrors.Num());
-		}
-		else
-		{
-			bSuccess = true;
-			StatusStr = TEXT("completed");
-			MessageStr = FString::Printf(TEXT("Live Coding compilation completed successfully in %.1fs"), CompilationTime);
-			UE_LOG(LogYesUeMcp, Log, TEXT("trigger-live-coding: Compilation successful (%.1fs)"), CompilationTime);
-		}
+		bSuccess = true;
+		StatusStr = TEXT("completed");
+		MessageStr = TEXT("Live Coding compilation completed successfully");
 		break;
 
 	case ELiveCodingCompileResult::NoChanges:
 		bSuccess = true;
 		StatusStr = TEXT("no_changes");
 		MessageStr = TEXT("No code changes detected - nothing to compile");
-		UE_LOG(LogYesUeMcp, Log, TEXT("trigger-live-coding: No changes detected"));
 		break;
 
 	case ELiveCodingCompileResult::Failure:
 		bSuccess = false;
 		StatusStr = TEXT("failed");
 		MessageStr = TEXT("Live Coding compilation failed. Check Output Log for errors.");
-		UE_LOG(LogYesUeMcp, Warning, TEXT("trigger-live-coding: Compilation failed (%.1fs)"), CompilationTime);
 		break;
 
 	case ELiveCodingCompileResult::Cancelled:
 		bSuccess = false;
 		StatusStr = TEXT("cancelled");
 		MessageStr = TEXT("Live Coding compilation was cancelled");
-		UE_LOG(LogYesUeMcp, Warning, TEXT("trigger-live-coding: Compilation cancelled"));
 		break;
 
 	case ELiveCodingCompileResult::CompileStillActive:
-		bSuccess = false;
-		StatusStr = TEXT("busy");
-		MessageStr = TEXT("A prior Live Coding compile is still in progress");
-		UE_LOG(LogYesUeMcp, Warning, TEXT("trigger-live-coding: Compile still active"));
+		bSuccess = true;
+		StatusStr = TEXT("compiling");
+		MessageStr = TEXT("Compilation still in progress. Call again with wait_for_completion=true to poll status.");
+		break;
+
+	case ELiveCodingCompileResult::InProgress:
+		bSuccess = true;
+		StatusStr = TEXT("compiling");
+		MessageStr = TEXT("Compilation in progress. Call again with wait_for_completion=true to poll status.");
 		break;
 
 	case ELiveCodingCompileResult::NotStarted:
 		bSuccess = false;
 		StatusStr = TEXT("not_started");
 		MessageStr = TEXT("Live Coding monitor could not be started");
-		UE_LOG(LogYesUeMcp, Warning, TEXT("trigger-live-coding: Could not start"));
 		break;
 
-	case ELiveCodingCompileResult::InProgress:
 	default:
 		bSuccess = false;
 		StatusStr = TEXT("unknown");
 		MessageStr = FString::Printf(TEXT("Unexpected compile result: %d"), static_cast<int32>(CompileResult));
-		UE_LOG(LogYesUeMcp, Warning, TEXT("trigger-live-coding: Unexpected result %d"), static_cast<int32>(CompileResult));
 		break;
 	}
 
@@ -195,15 +153,22 @@ FMcpToolResult UTriggerLiveCodingTool::ExecuteSynchronous(ILiveCodingModule* Liv
 	Result->SetStringField(TEXT("status"), StatusStr);
 	Result->SetStringField(TEXT("message"), MessageStr);
 
-	// Include error messages if any were captured
-	if (CompilationErrors.Num() > 0)
+	// 查询最近的编译错误日志
+	TArray<FMcpLogEntry> RecentErrors = FMcpLogCapture::Get().GetLogs(
+		TEXT("LogLiveCoding"),
+		ELogVerbosity::Error,
+		10,
+		TEXT("")
+	);
+
+	if (RecentErrors.Num() > 0)
 	{
 		TArray<TSharedPtr<FJsonValue>> ErrorArray;
-		for (const FString& Error : CompilationErrors)
+		for (const FMcpLogEntry& Entry : RecentErrors)
 		{
-			ErrorArray.Add(MakeShareable(new FJsonValueString(Error)));
+			ErrorArray.Add(MakeShareable(new FJsonValueString(Entry.Message)));
 		}
-		Result->SetArrayField(TEXT("errors"), ErrorArray);
+		Result->SetArrayField(TEXT("recent_errors"), ErrorArray);
 	}
 
 	return FMcpToolResult::Json(Result);

--- a/Source/YesUeMcpEditor/Private/Tools/CallFunctionTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/CallFunctionTool.cpp
@@ -1,6 +1,7 @@
 // Copyright softdaddy-o 2024. All Rights Reserved.
 
 #include "Tools/CallFunctionTool.h"
+#include "Tools/PIE/PieSessionTool.h"
 #include "YesUeMcpEditor.h"
 #include "Editor.h"
 #include "Engine/World.h"
@@ -71,6 +72,12 @@ FMcpToolResult UCallFunctionTool::Execute(
 	}
 
 	// Actor or component function
+	// PIE 过渡期保护：避免在 PIE 正在启动/停止时访问不稳定的世界对象
+	if (WorldParam.Equals(TEXT("pie"), ESearchCase::IgnoreCase) && UPieSessionTool::IsPIETransitioning())
+	{
+		return FMcpToolResult::Error(TEXT("PIE is currently transitioning (starting or stopping). Please wait and try again."));
+	}
+
 	UWorld* World = GetTargetWorld(WorldParam);
 	if (!World)
 	{
@@ -182,8 +189,17 @@ FMcpToolResult UCallFunctionTool::CallFunctionOnObject(UObject* Object, const FS
 		return FMcpToolResult::Error(FString::Printf(TEXT("Function not found: %s"), *FunctionName));
 	}
 
-	// Allocate and init parameters
-	uint8* ParamBuffer = (uint8*)FMemory_Alloca(Function->ParmsSize);
+	// 参数大小安全检查：防止超大参数导致内存问题（上限 64KB）
+	constexpr int32 MaxParmsSize = 64 * 1024;
+	if (Function->ParmsSize > MaxParmsSize)
+	{
+		return FMcpToolResult::Error(FString::Printf(
+			TEXT("Function '%s' parameter size (%d bytes) exceeds safety limit (%d bytes)"),
+			*FunctionName, Function->ParmsSize, MaxParmsSize));
+	}
+
+	// 使用堆分配代替 FMemory_Alloca，避免栈溢出风险
+	uint8* ParamBuffer = (uint8*)FMemory::Malloc(Function->ParmsSize);
 	FMemory::Memzero(ParamBuffer, Function->ParmsSize);
 
 	for (TFieldIterator<FProperty> It(Function); It && (It->PropertyFlags & CPF_Parm); ++It)
@@ -243,6 +259,7 @@ FMcpToolResult UCallFunctionTool::CallFunctionOnObject(UObject* Object, const FS
 	{
 		It->DestroyValue_InContainer(ParamBuffer);
 	}
+	FMemory::Free(ParamBuffer);
 
 	UE_LOG(LogYesUeMcp, Log, TEXT("call-function: Called %s on %s"), *FunctionName, *Object->GetName());
 	return FMcpToolResult::Json(Result);

--- a/Source/YesUeMcpEditor/Private/Tools/Level/QueryLevelTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Level/QueryLevelTool.cpp
@@ -1,6 +1,7 @@
 // Copyright softdaddy-o 2024. All Rights Reserved.
 
 #include "Tools/Level/QueryLevelTool.h"
+#include "Tools/PIE/PieSessionTool.h"
 #include "Editor.h"
 #include "Engine/World.h"
 #include "Engine/Level.h"
@@ -133,6 +134,11 @@ FMcpToolResult UQueryLevelTool::Execute(
 
 	if (WorldParam == TEXT("pie"))
 	{
+		// PIE 过渡期保护：避免在 PIE 启动/停止过程中访问正在创建/销毁的世界对象
+		if (UPieSessionTool::IsPIETransitioning())
+		{
+			return FMcpToolResult::Error(TEXT("PIE is currently transitioning (starting or stopping). Please wait and try again."));
+		}
 		// PIE only - fail if not running
 		for (const FWorldContext& WorldContext : GEngine->GetWorldContexts())
 		{
@@ -149,6 +155,18 @@ FMcpToolResult UQueryLevelTool::Execute(
 	}
 	else if (WorldParam == TEXT("auto"))
 	{
+		// PIE 过渡期保护
+		if (UPieSessionTool::IsPIETransitioning())
+		{
+			// auto 模式下 PIE 过渡中则回退到 editor world
+			World = GEditor->GetEditorWorldContext().World();
+			if (!World)
+			{
+				return FMcpToolResult::Error(TEXT("PIE is transitioning and no editor world available."));
+			}
+		}
+		else
+		{
 		// Auto mode: prefer PIE if available, else editor
 		for (const FWorldContext& WorldContext : GEngine->GetWorldContexts())
 		{
@@ -166,6 +184,7 @@ FMcpToolResult UQueryLevelTool::Execute(
 		{
 			return FMcpToolResult::Error(TEXT("No world loaded"));
 		}
+		} // end else (!IsPIETransitioning)
 	}
 	else
 	{
@@ -1061,6 +1080,21 @@ FMcpToolResult UQueryLevelTool::QueryExternalLevel(const FString& LevelPath, con
 
 	UE_LOG(LogYesUeMcp, Log, TEXT("query-level: External level query complete - %d actors returned"),
 		ActorsArray.Num());
+
+	// 卸载临时加载的外部关卡，避免内存泄漏
+	if (LoadedWorld && !LoadedWorld->HasAnyFlags(RF_Standalone))
+	{
+		UE_LOG(LogYesUeMcp, Log, TEXT("query-level: Unloading temporary external level '%s'"), *LevelPath);
+		// 清除对 Actor 的引用后，重置包的脏标记并卸载
+		UPackage* LevelPackage = LoadedWorld->GetOutermost();
+		if (LevelPackage)
+		{
+			LevelPackage->ClearDirtyFlag();
+			// 标记为可回收，让 GC 在下次运行时清理
+			LoadedWorld->ClearFlags(RF_Standalone);
+			LoadedWorld->MarkAsGarbage();
+		}
+	}
 
 	return FMcpToolResult::Json(Result);
 }

--- a/Source/YesUeMcpEditor/Private/Tools/PIE/PieInputTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/PIE/PieInputTool.cpp
@@ -1,6 +1,7 @@
 // Copyright softdaddy-o 2024. All Rights Reserved.
 
 #include "Tools/PIE/PieInputTool.h"
+#include "Tools/PIE/PieSessionTool.h"
 #include "YesUeMcpEditor.h"
 #include "Editor.h"
 #include "Engine/World.h"
@@ -94,6 +95,12 @@ FMcpToolResult UPieInputTool::Execute(
 	FString Action;
 	GetStringArg(Arguments, TEXT("action"), Action);
 	Action = Action.ToLower();
+
+	// 检查 PIE 是否正在过渡（启动/停止中），避免访问正在创建/销毁的世界对象
+	if (UPieSessionTool::IsPIETransitioning())
+	{
+		return FMcpToolResult::Error(TEXT("PIE is currently transitioning (starting/stopping). Please wait and try again."));
+	}
 
 	if (!GEditor->IsPlaySessionInProgress())
 	{

--- a/Source/YesUeMcpEditor/Private/Tools/PIE/PieSessionTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/PIE/PieSessionTool.cpp
@@ -15,9 +15,48 @@
 #include "Misc/Guid.h"
 #include "EngineUtils.h"
 
+// 静态成员初始化
+bool UPieSessionTool::bPIETransitioning = false;
+FDelegateHandle UPieSessionTool::PIEStartedHandle;
+FDelegateHandle UPieSessionTool::PIEEndedHandle;
+
+void UPieSessionTool::RegisterPIECallbacks()
+{
+	// 避免重复注册
+	UnregisterPIECallbacks();
+
+	// PIE 启动完成回调：世界已完全创建，清除过渡标志
+	PIEStartedHandle = FEditorDelegates::PostPIEStarted.AddLambda([](bool bIsSimulating)
+	{
+		UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: PIE started callback - clearing transition flag"));
+		bPIETransitioning = false;
+	});
+
+	// PIE 结束完成回调：世界已完全销毁，清除过渡标志
+	PIEEndedHandle = FEditorDelegates::EndPIE.AddLambda([](bool bIsSimulating)
+	{
+		UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: PIE ended callback - clearing transition flag"));
+		bPIETransitioning = false;
+	});
+}
+
+void UPieSessionTool::UnregisterPIECallbacks()
+{
+	if (PIEStartedHandle.IsValid())
+	{
+		FEditorDelegates::PostPIEStarted.Remove(PIEStartedHandle);
+		PIEStartedHandle.Reset();
+	}
+	if (PIEEndedHandle.IsValid())
+	{
+		FEditorDelegates::EndPIE.Remove(PIEEndedHandle);
+		PIEEndedHandle.Reset();
+	}
+}
+
 FString UPieSessionTool::GetToolDescription() const
 {
-	return TEXT("Control PIE (Play-In-Editor) sessions. Actions: 'start', 'stop', 'pause', 'resume', 'get-state', 'wait-for' (wait until condition met).");
+	return TEXT("Control PIE (Play-In-Editor) sessions. Actions: 'start', 'stop', 'pause', 'resume', 'get-state', 'wait-for' (non-blocking single check of condition, client polls).");
 }
 
 TMap<FString, FMcpSchemaProperty> UPieSessionTool::GetInputSchema() const
@@ -26,7 +65,7 @@ TMap<FString, FMcpSchemaProperty> UPieSessionTool::GetInputSchema() const
 
 	FMcpSchemaProperty Action;
 	Action.Type = TEXT("string");
-	Action.Description = TEXT("Action: 'start', 'stop', 'pause', 'resume', 'get-state', or 'wait-for'");
+	Action.Description = TEXT("Action: 'start', 'stop', 'pause', 'resume', 'get-state', or 'wait-for'. Note: start/stop/wait-for are non-blocking (fire-and-forget), use get-state to poll.");
 	Action.bRequired = true;
 	Schema.Add(TEXT("action"), Action);
 
@@ -79,17 +118,7 @@ TMap<FString, FMcpSchemaProperty> UPieSessionTool::GetInputSchema() const
 	ExpectedValue.bRequired = false;
 	Schema.Add(TEXT("expected"), ExpectedValue);
 
-	FMcpSchemaProperty WaitTimeout;
-	WaitTimeout.Type = TEXT("number");
-	WaitTimeout.Description = TEXT("[wait-for] Timeout in seconds (default: 10)");
-	WaitTimeout.bRequired = false;
-	Schema.Add(TEXT("wait_timeout"), WaitTimeout);
-
-	FMcpSchemaProperty PollInterval;
-	PollInterval.Type = TEXT("number");
-	PollInterval.Description = TEXT("[wait-for] Poll interval in seconds (default: 0.1)");
-	PollInterval.bRequired = false;
-	Schema.Add(TEXT("poll_interval"), PollInterval);
+	// wait_timeout 和 poll_interval 已移除：wait-for 现在是非阻塞的单次检查，客户端自行轮询并控制超时和间隔。
 
 	return Schema;
 }
@@ -186,17 +215,21 @@ FMcpToolResult UPieSessionTool::ExecuteStart(const TSharedPtr<FJsonObject>& Argu
 		}
 	}
 
+	// 设置 PIE 过渡标志并注册回调
+	bPIETransitioning = true;
+	RegisterPIECallbacks();
+
 	GEditor->RequestPlaySession(Params);
 
-	// Fire-and-forget: return immediately without blocking GameThread waiting for PIE ready.
-	// Client should poll PIE state via get-state action until state becomes "running".
+	// Fire-and-forget：立即返回，不阻塞 GameThread 等待 PIE 就绪。
+	// 客户端应通过 get-state action 轮询 PIE 状态直到 state 变为 "running"。
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetBoolField(TEXT("success"), true);
 	Result->SetStringField(TEXT("session_id"), GenerateSessionId());
 	Result->SetStringField(TEXT("state"), TEXT("starting"));
-	Result->SetStringField(TEXT("message"), TEXT("PIE start requested. Use get-state action to poll until state becomes 'running'."));
+	Result->SetStringField(TEXT("message"), TEXT("PIE start requested. Use get-state action to poll until state becomes 'running'. Other tools that access PIE world will be blocked until PIE is ready."));
 
-	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Start requested (mode=%s)"), *Mode);
+	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Start requested (mode=%s), transition flag set"), *Mode);
 	return FMcpToolResult::Json(Result);
 }
 
@@ -210,16 +243,20 @@ FMcpToolResult UPieSessionTool::ExecuteStop(const TSharedPtr<FJsonObject>& Argum
 		return FMcpToolResult::Json(Result);
 	}
 
+	// 设置 PIE 过渡标志并注册回调
+	bPIETransitioning = true;
+	RegisterPIECallbacks();
+
 	GEditor->RequestEndPlayMap();
 
-	// Fire-and-forget: return immediately without blocking GameThread waiting for PIE to fully stop.
-	// Client should poll PIE state via get-state action until state becomes "not_running".
+	// Fire-and-forget：立即返回，不阻塞 GameThread 等待 PIE 完全停止。
+	// 客户端应通过 get-state action 轮询 PIE 状态直到 state 变为 "not_running"。
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetBoolField(TEXT("success"), true);
 	Result->SetStringField(TEXT("state"), TEXT("stopping"));
-	Result->SetStringField(TEXT("message"), TEXT("PIE stop requested. Use get-state action to poll until state becomes 'not_running'."));
+	Result->SetStringField(TEXT("message"), TEXT("PIE stop requested. Use get-state action to poll until state becomes 'not_running'. Other tools that access PIE world will be blocked until PIE cleanup completes."));
 
-	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Stop requested"));
+	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Stop requested, transition flag set"));
 	return FMcpToolResult::Json(Result);
 }
 
@@ -362,25 +399,9 @@ UWorld* UPieSessionTool::GetPIEWorld() const
 	return nullptr;
 }
 
-bool UPieSessionTool::WaitForPIEReady(float TimeoutSeconds) const
-{
-	const double EndTime = FPlatformTime::Seconds() + TimeoutSeconds;
-
-	while (FPlatformTime::Seconds() < EndTime)
-	{
-		FPlatformProcess::Sleep(0.1f);
-
-		if (GEditor->IsPlaySessionInProgress())
-		{
-			UWorld* PIEWorld = GetPIEWorld();
-			if (PIEWorld && PIEWorld->GetFirstPlayerController())
-			{
-				return true;
-			}
-		}
-	}
-	return false;
-}
+// WaitForPIEReady 已移除：该函数在 GameThread 上使用 while+Sleep 阻塞循环，
+// 会导致编辑器卡死。ExecuteStart 已改为 Fire-and-forget 模式，不再需要此函数。
+// 客户端应通过 get-state action 轮询 PIE 状态。
 
 TSharedPtr<FJsonObject> UPieSessionTool::GetWorldInfo(UWorld* PIEWorld) const
 {
@@ -434,6 +455,10 @@ TArray<TSharedPtr<FJsonValue>> UPieSessionTool::GetPlayersInfo(UWorld* PIEWorld)
 
 FMcpToolResult UPieSessionTool::ExecuteWaitFor(const TSharedPtr<FJsonObject>& Arguments)
 {
+	// Non-blocking 实现：只执行一次条件检查并立即返回当前状态。
+	// 客户端应自行轮询此 action 直到 condition_met 为 true 或自行判断超时。
+	// 这避免了在 GameThread 上使用 while+Sleep 阻塞循环导致编辑器卡死。
+
 	if (!GEditor->IsPlaySessionInProgress())
 	{
 		return FMcpToolResult::Error(TEXT("No PIE session running"));
@@ -448,8 +473,6 @@ FMcpToolResult UPieSessionTool::ExecuteWaitFor(const TSharedPtr<FJsonObject>& Ar
 	FString ActorName = GetStringArgOrDefault(Arguments, TEXT("actor_name"));
 	FString PropertyName = GetStringArgOrDefault(Arguments, TEXT("property"));
 	FString Operator = GetStringArgOrDefault(Arguments, TEXT("operator"), TEXT("equals"));
-	float WaitTimeout = GetFloatArgOrDefault(Arguments, TEXT("wait_timeout"), 10.0f);
-	float PollInterval = GetFloatArgOrDefault(Arguments, TEXT("poll_interval"), 0.1f);
 
 	if (ActorName.IsEmpty())
 	{
@@ -467,113 +490,46 @@ FMcpToolResult UPieSessionTool::ExecuteWaitFor(const TSharedPtr<FJsonObject>& Ar
 		return FMcpToolResult::Error(TEXT("expected value is required for wait-for action"));
 	}
 
-	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Waiting for %s.%s %s ..."),
-		*ActorName, *PropertyName, *Operator);
-
-	const double StartTime = FPlatformTime::Seconds();
-	const double EndTime = StartTime + WaitTimeout;
-	bool bConditionMet = false;
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	TSharedPtr<FJsonValue> ActualValue;
+	bool bConditionMet = false;
 
-	while (FPlatformTime::Seconds() < EndTime)
+	// 查找 Actor
+	AActor* Actor = FindActorByName(PIEWorld, ActorName);
+	if (!Actor)
 	{
-		// Check if PIE is still running
-		if (!GEditor->IsPlaySessionInProgress())
-		{
-			return FMcpToolResult::Error(TEXT("PIE session ended while waiting"));
-		}
-
-		// Find actor
-		AActor* Actor = FindActorByName(PIEWorld, ActorName);
-		if (!Actor)
-		{
-			// Actor might not exist yet, keep waiting
-			FPlatformProcess::Sleep(PollInterval);
-			continue;
-		}
-
-		// Get property value
-		ActualValue = GetActorProperty(Actor, PropertyName);
-		if (!ActualValue.IsValid())
-		{
-			FPlatformProcess::Sleep(PollInterval);
-			continue;
-		}
-
-		// Compare values
-		bool bMatch = false;
-		if (Operator == TEXT("equals") || Operator == TEXT("eq") || Operator == TEXT("=="))
-		{
-			// Compare based on type
-			if (ActualValue->Type == EJson::Boolean && ExpectedJson->Type == EJson::Boolean)
-			{
-				bMatch = ActualValue->AsBool() == ExpectedJson->AsBool();
-			}
-			else if (ActualValue->Type == EJson::Number && ExpectedJson->Type == EJson::Number)
-			{
-				bMatch = FMath::IsNearlyEqual(ActualValue->AsNumber(), ExpectedJson->AsNumber(), 0.001);
-			}
-			else if (ActualValue->Type == EJson::String && ExpectedJson->Type == EJson::String)
-			{
-				bMatch = ActualValue->AsString().Equals(ExpectedJson->AsString(), ESearchCase::IgnoreCase);
-			}
-			else
-			{
-				// Fallback: compare as strings
-				bMatch = ActualValue->AsString().Equals(ExpectedJson->AsString());
-			}
-		}
-		else if (Operator == TEXT("not_equals") || Operator == TEXT("ne") || Operator == TEXT("!="))
-		{
-			if (ActualValue->Type == EJson::Boolean && ExpectedJson->Type == EJson::Boolean)
-			{
-				bMatch = ActualValue->AsBool() != ExpectedJson->AsBool();
-			}
-			else if (ActualValue->Type == EJson::Number && ExpectedJson->Type == EJson::Number)
-			{
-				bMatch = !FMath::IsNearlyEqual(ActualValue->AsNumber(), ExpectedJson->AsNumber(), 0.001);
-			}
-			else
-			{
-				bMatch = !ActualValue->AsString().Equals(ExpectedJson->AsString());
-			}
-		}
-		else if (Operator == TEXT("less_than") || Operator == TEXT("lt") || Operator == TEXT("<"))
-		{
-			bMatch = ActualValue->AsNumber() < ExpectedJson->AsNumber();
-		}
-		else if (Operator == TEXT("greater_than") || Operator == TEXT("gt") || Operator == TEXT(">"))
-		{
-			bMatch = ActualValue->AsNumber() > ExpectedJson->AsNumber();
-		}
-		else if (Operator == TEXT("less_equal") || Operator == TEXT("le") || Operator == TEXT("<="))
-		{
-			bMatch = ActualValue->AsNumber() <= ExpectedJson->AsNumber();
-		}
-		else if (Operator == TEXT("greater_equal") || Operator == TEXT("ge") || Operator == TEXT(">="))
-		{
-			bMatch = ActualValue->AsNumber() >= ExpectedJson->AsNumber();
-		}
-		else if (Operator == TEXT("contains"))
-		{
-			bMatch = ActualValue->AsString().Contains(ExpectedJson->AsString());
-		}
-
-		if (bMatch)
-		{
-			bConditionMet = true;
-			break;
-		}
-
-		FPlatformProcess::Sleep(PollInterval);
+		// Actor 尚未存在，返回 not_found 状态，客户端可继续轮询
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("condition_met"), false);
+		Result->SetStringField(TEXT("status"), TEXT("actor_not_found"));
+		Result->SetStringField(TEXT("message"), FString::Printf(TEXT("Actor '%s' not found yet. Poll again to retry."), *ActorName));
+		return FMcpToolResult::Json(Result);
 	}
 
-	double WaitTime = FPlatformTime::Seconds() - StartTime;
+	// 获取属性值
+	ActualValue = GetActorProperty(Actor, PropertyName);
+	if (!ActualValue.IsValid())
+	{
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("condition_met"), false);
+		Result->SetStringField(TEXT("status"), TEXT("property_not_found"));
+		Result->SetStringField(TEXT("message"), FString::Printf(TEXT("Property '%s' not found on actor '%s'. Poll again to retry."), *PropertyName, *ActorName));
+		return FMcpToolResult::Json(Result);
+	}
 
-	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
-	Result->SetBoolField(TEXT("success"), bConditionMet);
+	// 比较值（单次检查）
+	bool bMatch = CompareJsonValues(ActualValue, ExpectedJson, Operator);
+
+	if (bMatch)
+	{
+		bConditionMet = true;
+		UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: wait-for condition met (%s.%s %s)"),
+			*ActorName, *PropertyName, *Operator);
+	}
+
+	Result->SetBoolField(TEXT("success"), true);
 	Result->SetBoolField(TEXT("condition_met"), bConditionMet);
-	Result->SetNumberField(TEXT("wait_time_seconds"), WaitTime);
+	Result->SetStringField(TEXT("status"), bConditionMet ? TEXT("condition_met") : TEXT("pending"));
 
 	if (ActualValue.IsValid())
 	{
@@ -582,12 +538,7 @@ FMcpToolResult UPieSessionTool::ExecuteWaitFor(const TSharedPtr<FJsonObject>& Ar
 
 	if (!bConditionMet)
 	{
-		Result->SetStringField(TEXT("message"), FString::Printf(TEXT("Timeout after %.1f seconds"), WaitTime));
-		UE_LOG(LogYesUeMcp, Warning, TEXT("pie-session: wait-for timed out after %.1fs"), WaitTime);
-	}
-	else
-	{
-		UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: wait-for condition met in %.1fs"), WaitTime);
+		Result->SetStringField(TEXT("message"), TEXT("Condition not met yet. Poll again to retry."));
 	}
 
 	return FMcpToolResult::Json(Result);
@@ -642,4 +593,69 @@ TSharedPtr<FJsonValue> UPieSessionTool::GetActorProperty(AActor* Actor, const FS
 	FString ExportedText;
 	Property->ExportTextItem_Direct(ExportedText, ValuePtr, nullptr, nullptr, PPF_None);
 	return MakeShareable(new FJsonValueString(ExportedText));
+}
+
+bool UPieSessionTool::CompareJsonValues(const TSharedPtr<FJsonValue>& ActualValue, const TSharedPtr<FJsonValue>& ExpectedJson, const FString& Operator) const
+{
+	if (!ActualValue.IsValid() || !ExpectedJson.IsValid())
+	{
+		return false;
+	}
+
+	if (Operator == TEXT("equals") || Operator == TEXT("eq") || Operator == TEXT("=="))
+	{
+		if (ActualValue->Type == EJson::Boolean && ExpectedJson->Type == EJson::Boolean)
+		{
+			return ActualValue->AsBool() == ExpectedJson->AsBool();
+		}
+		else if (ActualValue->Type == EJson::Number && ExpectedJson->Type == EJson::Number)
+		{
+			return FMath::IsNearlyEqual(ActualValue->AsNumber(), ExpectedJson->AsNumber(), 0.001);
+		}
+		else if (ActualValue->Type == EJson::String && ExpectedJson->Type == EJson::String)
+		{
+			return ActualValue->AsString().Equals(ExpectedJson->AsString(), ESearchCase::IgnoreCase);
+		}
+		else
+		{
+			return ActualValue->AsString().Equals(ExpectedJson->AsString());
+		}
+	}
+	else if (Operator == TEXT("not_equals") || Operator == TEXT("ne") || Operator == TEXT("!="))
+	{
+		if (ActualValue->Type == EJson::Boolean && ExpectedJson->Type == EJson::Boolean)
+		{
+			return ActualValue->AsBool() != ExpectedJson->AsBool();
+		}
+		else if (ActualValue->Type == EJson::Number && ExpectedJson->Type == EJson::Number)
+		{
+			return !FMath::IsNearlyEqual(ActualValue->AsNumber(), ExpectedJson->AsNumber(), 0.001);
+		}
+		else
+		{
+			return !ActualValue->AsString().Equals(ExpectedJson->AsString());
+		}
+	}
+	else if (Operator == TEXT("less_than") || Operator == TEXT("lt") || Operator == TEXT("<"))
+	{
+		return ActualValue->AsNumber() < ExpectedJson->AsNumber();
+	}
+	else if (Operator == TEXT("greater_than") || Operator == TEXT("gt") || Operator == TEXT(">"))
+	{
+		return ActualValue->AsNumber() > ExpectedJson->AsNumber();
+	}
+	else if (Operator == TEXT("less_equal") || Operator == TEXT("le") || Operator == TEXT("<="))
+	{
+		return ActualValue->AsNumber() <= ExpectedJson->AsNumber();
+	}
+	else if (Operator == TEXT("greater_equal") || Operator == TEXT("ge") || Operator == TEXT(">="))
+	{
+		return ActualValue->AsNumber() >= ExpectedJson->AsNumber();
+	}
+	else if (Operator == TEXT("contains"))
+	{
+		return ActualValue->AsString().Contains(ExpectedJson->AsString());
+	}
+
+	return false;
 }

--- a/Source/YesUeMcpEditor/Private/Tools/PIE/PieSessionTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/PIE/PieSessionTool.cpp
@@ -188,8 +188,8 @@ FMcpToolResult UPieSessionTool::ExecuteStart(const TSharedPtr<FJsonObject>& Argu
 
 	GEditor->RequestPlaySession(Params);
 
-	// Fire-and-forget：立即返回，不阻塞 GameThread 等待 PIE 就绪。
-	// 客户端应通过 get-state action 轮询 PIE 状态直到 state 变为 "running"。
+	// Fire-and-forget: return immediately without blocking GameThread waiting for PIE ready.
+	// Client should poll PIE state via get-state action until state becomes "running".
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetBoolField(TEXT("success"), true);
 	Result->SetStringField(TEXT("session_id"), GenerateSessionId());
@@ -212,8 +212,8 @@ FMcpToolResult UPieSessionTool::ExecuteStop(const TSharedPtr<FJsonObject>& Argum
 
 	GEditor->RequestEndPlayMap();
 
-	// Fire-and-forget：立即返回，不阻塞 GameThread 等待 PIE 完全停止。
-	// 客户端应通过 get-state action 轮询 PIE 状态直到 state 变为 "not_running"。
+	// Fire-and-forget: return immediately without blocking GameThread waiting for PIE to fully stop.
+	// Client should poll PIE state via get-state action until state becomes "not_running".
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetBoolField(TEXT("success"), true);
 	Result->SetStringField(TEXT("state"), TEXT("stopping"));

--- a/Source/YesUeMcpEditor/Private/Tools/PIE/PieSessionTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/PIE/PieSessionTool.cpp
@@ -188,45 +188,15 @@ FMcpToolResult UPieSessionTool::ExecuteStart(const TSharedPtr<FJsonObject>& Argu
 
 	GEditor->RequestPlaySession(Params);
 
-	if (!WaitForPIEReady(Timeout))
-	{
-		return FMcpToolResult::Error(FString::Printf(TEXT("PIE did not start within %.0f seconds"), Timeout));
-	}
-
-	UWorld* PIEWorld = GetPIEWorld();
-	if (!PIEWorld)
-	{
-		return FMcpToolResult::Error(TEXT("PIE started but could not find PIE world"));
-	}
-
-	// Get player info
-	TArray<double> PlayerStartLocation = {0, 0, 0};
-	TArray<AActor*> PlayerStarts;
-	UGameplayStatics::GetAllActorsOfClass(PIEWorld, APlayerStart::StaticClass(), PlayerStarts);
-	if (PlayerStarts.Num() > 0)
-	{
-		FVector Loc = PlayerStarts[0]->GetActorLocation();
-		PlayerStartLocation = {Loc.X, Loc.Y, Loc.Z};
-	}
-
-	APlayerController* PC = PIEWorld->GetFirstPlayerController();
-	FString PlayerPawnName = PC && PC->GetPawn() ? PC->GetPawn()->GetName() : TEXT("None");
-
+	// Fire-and-forget：立即返回，不阻塞 GameThread 等待 PIE 就绪。
+	// 客户端应通过 get-state action 轮询 PIE 状态直到 state 变为 "running"。
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetBoolField(TEXT("success"), true);
 	Result->SetStringField(TEXT("session_id"), GenerateSessionId());
-	Result->SetStringField(TEXT("world_name"), PIEWorld->GetName());
-	Result->SetStringField(TEXT("state"), TEXT("running"));
-	Result->SetStringField(TEXT("player_pawn"), PlayerPawnName);
+	Result->SetStringField(TEXT("state"), TEXT("starting"));
+	Result->SetStringField(TEXT("message"), TEXT("PIE start requested. Use get-state action to poll until state becomes 'running'."));
 
-	TArray<TSharedPtr<FJsonValue>> StartLocArray;
-	for (double Val : PlayerStartLocation)
-	{
-		StartLocArray.Add(MakeShareable(new FJsonValueNumber(Val)));
-	}
-	Result->SetArrayField(TEXT("player_start"), StartLocArray);
-
-	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Started (world=%s)"), *PIEWorld->GetName());
+	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Start requested (mode=%s)"), *Mode);
 	return FMcpToolResult::Json(Result);
 }
 
@@ -242,22 +212,14 @@ FMcpToolResult UPieSessionTool::ExecuteStop(const TSharedPtr<FJsonObject>& Argum
 
 	GEditor->RequestEndPlayMap();
 
-	const double WaitStart = FPlatformTime::Seconds();
-	while (GEditor->IsPlaySessionInProgress() && (FPlatformTime::Seconds() - WaitStart) < 5.0)
-	{
-		FPlatformProcess::Sleep(0.05f);
-	}
-
-	if (GEditor->IsPlaySessionInProgress())
-	{
-		return FMcpToolResult::Error(TEXT("Failed to stop PIE within timeout"));
-	}
-
+	// Fire-and-forget：立即返回，不阻塞 GameThread 等待 PIE 完全停止。
+	// 客户端应通过 get-state action 轮询 PIE 状态直到 state 变为 "not_running"。
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetBoolField(TEXT("success"), true);
-	Result->SetStringField(TEXT("state"), TEXT("stopped"));
+	Result->SetStringField(TEXT("state"), TEXT("stopping"));
+	Result->SetStringField(TEXT("message"), TEXT("PIE stop requested. Use get-state action to poll until state becomes 'not_running'."));
 
-	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Stopped"));
+	UE_LOG(LogYesUeMcp, Log, TEXT("pie-session: Stop requested"));
 	return FMcpToolResult::Json(Result);
 }
 

--- a/Source/YesUeMcpEditor/Private/Tools/References/FindReferencesTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/References/FindReferencesTool.cpp
@@ -209,6 +209,17 @@ FMcpToolResult UFindReferencesTool::FindPropertyReferences(const FString& AssetP
 	// Get Blueprints to search
 	TArray<FAssetData> BlueprintsToSearch = GetBlueprintsInPath(AssetPath);
 
+	// 蓝图全量加载数量上限，防止 GameThread 长时间阻塞
+	constexpr int32 MaxBlueprintsToLoad = 200;
+	bool bBlueprintsTruncated = false;
+	if (BlueprintsToSearch.Num() > MaxBlueprintsToLoad)
+	{
+		UE_LOG(LogYesUeMcp, Warning, TEXT("find-references: Path '%s' contains %d blueprints, truncating to %d to avoid long blocking"),
+			*AssetPath, BlueprintsToSearch.Num(), MaxBlueprintsToLoad);
+		bBlueprintsTruncated = true;
+		BlueprintsToSearch.SetNum(MaxBlueprintsToLoad);
+	}
+
 	// Build result
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetStringField(TEXT("type"), TEXT("property"));
@@ -453,6 +464,17 @@ FMcpToolResult UFindReferencesTool::FindNodeReferences(const FString& AssetPath,
 		BlueprintsToSearch = GetBlueprintsInPath(AssetPath);
 	}
 
+	// 蓝图全量加载数量上限，防止 GameThread 长时间阻塞
+	constexpr int32 MaxBlueprintsToLoad = 200;
+	bool bBlueprintsTruncated = false;
+	if (BlueprintsToSearch.Num() > MaxBlueprintsToLoad)
+	{
+		UE_LOG(LogYesUeMcp, Warning, TEXT("find-references: Path '%s' contains %d blueprints, truncating to %d to avoid long blocking"),
+			*AssetPath, BlueprintsToSearch.Num(), MaxBlueprintsToLoad);
+		bBlueprintsTruncated = true;
+		BlueprintsToSearch.SetNum(MaxBlueprintsToLoad);
+	}
+
 	for (const FAssetData& AssetData : BlueprintsToSearch)
 	{
 		if (UsagesArray.Num() >= Limit)
@@ -558,15 +580,32 @@ FMcpToolResult UFindReferencesTool::FindNodeReferences(const FString& AssetPath,
 	Result->SetNumberField(TEXT("count"), UsagesArray.Num());
 	Result->SetNumberField(TEXT("blueprints_searched"), BlueprintsSearched);
 	Result->SetBoolField(TEXT("truncated"), UsagesArray.Num() >= Limit);
+	if (bBlueprintsTruncated)
+	{
+		Result->SetBoolField(TEXT("blueprints_truncated"), true);
+		Result->SetNumberField(TEXT("max_blueprints_to_load"), MaxBlueprintsToLoad);
+		Result->SetStringField(TEXT("warning"), FString::Printf(TEXT("Search path contains too many blueprints. Only the first %d were loaded. Use a more specific asset_path to narrow results."), MaxBlueprintsToLoad));
+	}
 
 	return FMcpToolResult::Json(Result);
 }
 
 FMcpToolResult UFindReferencesTool::FindNodeReferencesLegacy(const FString& AssetPath, const FString& NodeClass,
-													   const FString& FunctionName, int32 Limit)
+														   const FString& FunctionName, int32 Limit)
 {
 	// Get Blueprints to search
 	TArray<FAssetData> BlueprintsToSearch = GetBlueprintsInPath(AssetPath);
+
+	// 蓝图全量加载数量上限，防止 GameThread 长时间阻塞
+	constexpr int32 MaxBlueprintsToLoadLegacy = 200;
+	bool bBlueprintsTruncatedLegacy = false;
+	if (BlueprintsToSearch.Num() > MaxBlueprintsToLoadLegacy)
+	{
+		UE_LOG(LogYesUeMcp, Warning, TEXT("find-references: Path '%s' contains %d blueprints, truncating to %d to avoid long blocking"),
+			*AssetPath, BlueprintsToSearch.Num(), MaxBlueprintsToLoadLegacy);
+		bBlueprintsTruncatedLegacy = true;
+		BlueprintsToSearch.SetNum(MaxBlueprintsToLoadLegacy);
+	}
 
 	// Build result
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
@@ -693,6 +732,12 @@ FMcpToolResult UFindReferencesTool::FindNodeReferencesLegacy(const FString& Asse
 	Result->SetNumberField(TEXT("count"), UsagesArray.Num());
 	Result->SetNumberField(TEXT("blueprints_searched"), BlueprintsSearched);
 	Result->SetBoolField(TEXT("truncated"), UsagesArray.Num() >= Limit);
+	if (bBlueprintsTruncatedLegacy)
+	{
+		Result->SetBoolField(TEXT("blueprints_truncated"), true);
+		Result->SetNumberField(TEXT("max_blueprints_to_load"), MaxBlueprintsToLoadLegacy);
+		Result->SetStringField(TEXT("warning"), FString::Printf(TEXT("Search path contains too many blueprints. Only the first %d were loaded. Use a more specific asset_path to narrow results."), MaxBlueprintsToLoadLegacy));
+	}
 
 	return FMcpToolResult::Json(Result);
 }

--- a/Source/YesUeMcpEditor/Private/Tools/Scripting/RunPythonScriptTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Scripting/RunPythonScriptTool.cpp
@@ -3,6 +3,7 @@
 #include "Tools/Scripting/RunPythonScriptTool.h"
 #include "YesUeMcpEditor.h"
 #include "IPythonScriptPlugin.h"
+#include "Tools/PIE/PieSessionTool.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 #include "Engine/Engine.h"
@@ -52,6 +53,14 @@ FMcpToolResult URunPythonScriptTool::Execute(
 	{
 		UE_LOG(LogYesUeMcp, Warning, TEXT("run-python-script: PythonScriptPlugin is not loaded"));
 		return FMcpToolResult::Error(TEXT("PythonScriptPlugin is not enabled. Enable it in Edit > Plugins > Scripting > Python Editor Script Plugin"));
+	}
+
+	// 安全检查：PIE 正在启动或停止时，拒绝执行 Python 脚本
+	// 避免在 PIE 世界创建/销毁过程中访问不稳定的对象导致编辑器死锁或崩溃
+	if (UPieSessionTool::IsPIETransitioning())
+	{
+		UE_LOG(LogYesUeMcp, Warning, TEXT("run-python-script: Rejected - PIE is transitioning (starting or stopping)"));
+		return FMcpToolResult::Error(TEXT("PIE is currently transitioning (starting or stopping). Wait for PIE to finish transitioning by polling pie-session get-state, then retry."));
 	}
 
 	IPythonScriptPlugin* PythonPlugin = IPythonScriptPlugin::Get();
@@ -123,7 +132,7 @@ FMcpToolResult URunPythonScriptTool::Execute(
 	                          Output.Contains(TEXT("load_level")) ||
 	                          Output.Contains(TEXT("Loading map"));
 
-	// Fix: only run GC when level loading is detected, to avoid use-after-free on error paths
+	// 方案A修复：仅在检测到 level 加载操作时才执行 GC，避免异常路径下的 use-after-free
 	if (bLevelLoadDetected)
 	{
 		CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
@@ -170,8 +179,8 @@ FString URunPythonScriptTool::ExecutePython(const FString& Command, bool& bOutSu
 	FDateTime StartTime = FDateTime::Now();
 
 	// Wrap script with error handling
-	// Fix: prepend indent to the first line as well, then indent all subsequent lines
-	// so every line inside the try: block has correct 4-space indentation
+	// 方案B修复：先给第一行也加上缩进（"    " + Script），再将所有换行后也加缩进
+	// 这样 try: 块内的每一行都有正确的4空格缩进
 	FString IndentedCommand = TEXT("    ") + Command.Replace(TEXT("\n"), TEXT("\n    "));
 	FString WrappedScript = FString::Printf(TEXT(
 		"_mcp_success = True\n"
@@ -188,10 +197,10 @@ FString URunPythonScriptTool::ExecutePython(const FString& Command, bool& bOutSu
 	// Execute the script
 	PythonPlugin->ExecPythonCommand(*WrappedScript);
 
-	// Deferred to Execute() - only run GC when level loading is detected
-	// Originally calling CollectGarbage unconditionally caused use-after-free crash on Python errors
-	// (GetTypeHash(FUtf8String) -> Strihash_DEPRECATED -> CodepointFromUtf8 -> Access Violation)
-	// Deferred to Execute() - only run GC when level loading is detected
+	// 方案A修复：仅在脚本执行完毕后且检测到可能涉及 level 加载的操作时才执行 GC
+	// 原本每次都无条件调用 CollectGarbage 会在 Python 执行异常后触发 use-after-free 崩溃
+	// (GetTypeHash(FUtf8String) → Strihash_DEPRECATED → CodepointFromUtf8 → Access Violation)
+	// 延迟到下方检测到 level 加载时再执行 GC
 
 	// Capture output from LogPython category
 	TArray<FMcpLogEntry> Logs = FMcpLogCapture::Get().GetLogs(

--- a/Source/YesUeMcpEditor/Private/Tools/Scripting/RunPythonScriptTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Scripting/RunPythonScriptTool.cpp
@@ -123,6 +123,12 @@ FMcpToolResult URunPythonScriptTool::Execute(
 	                          Output.Contains(TEXT("load_level")) ||
 	                          Output.Contains(TEXT("Loading map"));
 
+	// 方案A修复：仅在检测到 level 加载操作时才执行 GC，避免异常路径下的 use-after-free
+	if (bLevelLoadDetected)
+	{
+		CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
+	}
+
 	if (bSuccess)
 	{
 		Result->SetStringField(TEXT("output"), Output);
@@ -164,6 +170,9 @@ FString URunPythonScriptTool::ExecutePython(const FString& Command, bool& bOutSu
 	FDateTime StartTime = FDateTime::Now();
 
 	// Wrap script with error handling
+	// 方案B修复：先给第一行也加上缩进（"    " + Script），再将所有换行后也加缩进
+	// 这样 try: 块内的每一行都有正确的4空格缩进
+	FString IndentedCommand = TEXT("    ") + Command.Replace(TEXT("\n"), TEXT("\n    "));
 	FString WrappedScript = FString::Printf(TEXT(
 		"_mcp_success = True\n"
 		"_mcp_error = ''\n"
@@ -174,15 +183,15 @@ FString URunPythonScriptTool::ExecutePython(const FString& Command, bool& bOutSu
 		"    _mcp_error = str(e)\n"
 		"    import traceback\n"
 		"    print(traceback.format_exc())\n"
-	), *Command.Replace(TEXT("\n"), TEXT("\n    "))); // Indent user script
+	), *IndentedCommand);
 
 	// Execute the script
 	PythonPlugin->ExecPythonCommand(*WrappedScript);
 
-	// Force garbage collection to clean up any orphaned objects created by the script
-	// This is critical for scripts that load levels, as they can leave orphaned world/package refs
-	// that would otherwise trigger "World Memory Leaks" fatal errors
-	CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
+	// 方案A修复：仅在脚本执行完毕后且检测到可能涉及 level 加载的操作时才执行 GC
+	// 原本每次都无条件调用 CollectGarbage 会在 Python 执行异常后触发 use-after-free 崩溃
+	// (GetTypeHash(FUtf8String) → Strihash_DEPRECATED → CodepointFromUtf8 → Access Violation)
+	// 延迟到下方检测到 level 加载时再执行 GC
 
 	// Capture output from LogPython category
 	TArray<FMcpLogEntry> Logs = FMcpLogCapture::Get().GetLogs(

--- a/Source/YesUeMcpEditor/Private/Tools/Scripting/RunPythonScriptTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Scripting/RunPythonScriptTool.cpp
@@ -123,7 +123,7 @@ FMcpToolResult URunPythonScriptTool::Execute(
 	                          Output.Contains(TEXT("load_level")) ||
 	                          Output.Contains(TEXT("Loading map"));
 
-	// 方案A修复：仅在检测到 level 加载操作时才执行 GC，避免异常路径下的 use-after-free
+	// Fix: only run GC when level loading is detected, to avoid use-after-free on error paths
 	if (bLevelLoadDetected)
 	{
 		CollectGarbage(GARBAGE_COLLECTION_KEEPFLAGS);
@@ -170,8 +170,8 @@ FString URunPythonScriptTool::ExecutePython(const FString& Command, bool& bOutSu
 	FDateTime StartTime = FDateTime::Now();
 
 	// Wrap script with error handling
-	// 方案B修复：先给第一行也加上缩进（"    " + Script），再将所有换行后也加缩进
-	// 这样 try: 块内的每一行都有正确的4空格缩进
+	// Fix: prepend indent to the first line as well, then indent all subsequent lines
+	// so every line inside the try: block has correct 4-space indentation
 	FString IndentedCommand = TEXT("    ") + Command.Replace(TEXT("\n"), TEXT("\n    "));
 	FString WrappedScript = FString::Printf(TEXT(
 		"_mcp_success = True\n"
@@ -188,10 +188,10 @@ FString URunPythonScriptTool::ExecutePython(const FString& Command, bool& bOutSu
 	// Execute the script
 	PythonPlugin->ExecPythonCommand(*WrappedScript);
 
-	// 方案A修复：仅在脚本执行完毕后且检测到可能涉及 level 加载的操作时才执行 GC
-	// 原本每次都无条件调用 CollectGarbage 会在 Python 执行异常后触发 use-after-free 崩溃
-	// (GetTypeHash(FUtf8String) → Strihash_DEPRECATED → CodepointFromUtf8 → Access Violation)
-	// 延迟到下方检测到 level 加载时再执行 GC
+	// Deferred to Execute() - only run GC when level loading is detected
+	// Originally calling CollectGarbage unconditionally caused use-after-free crash on Python errors
+	// (GetTypeHash(FUtf8String) -> Strihash_DEPRECATED -> CodepointFromUtf8 -> Access Violation)
+	// Deferred to Execute() - only run GC when level loading is detected
 
 	// Capture output from LogPython category
 	TArray<FMcpLogEntry> Logs = FMcpLogCapture::Get().GetLogs(

--- a/Source/YesUeMcpEditor/Private/Tools/Write/SetPropertyTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Write/SetPropertyTool.cpp
@@ -147,16 +147,17 @@ FMcpToolResult USetPropertyTool::Execute(
 			// Try InheritableComponentHandler (inherited component overrides)
 			if (!bFoundComponent)
 			{
-				UInheritableComponentHandler* ICH = Blueprint->GetInheritableComponentHandler(true);
+			UInheritableComponentHandler* ICH = Blueprint->GetInheritableComponentHandler(true);
 				if (ICH)
 				{
-					TArray<FComponentKey> OverrideKeys;
-					ICH->GetAllTemplates(OverrideKeys);
+					TArray<UActorComponent*> OverrideTemplates;
+					ICH->GetAllTemplates(OverrideTemplates);
 
-					for (const FComponentKey& Key : OverrideKeys)
+					for (UActorComponent* ExistingTemplate : OverrideTemplates)
 					{
+						if (!ExistingTemplate) continue;
+						FComponentKey Key = ICH->FindKey(ExistingTemplate);
 						FString KeyName = Key.GetSCSVariableName().ToString();
-						UActorComponent* ExistingTemplate = ICH->GetOverridenComponentTemplate(Key);
 
 						if (KeyName == ComponentName || (ExistingTemplate && ExistingTemplate->GetName() == ComponentName))
 						{

--- a/Source/YesUeMcpEditor/Private/Tools/Write/SpawnActorTool.cpp
+++ b/Source/YesUeMcpEditor/Private/Tools/Write/SpawnActorTool.cpp
@@ -1,6 +1,7 @@
 // Copyright softdaddy-o 2024. All Rights Reserved.
 
 #include "Tools/Write/SpawnActorTool.h"
+#include "Tools/PIE/PieSessionTool.h"
 #include "Utils/McpAssetModifier.h"
 #include "YesUeMcpEditor.h"
 #include "Editor.h"
@@ -107,6 +108,12 @@ FMcpToolResult USpawnActorTool::Execute(
 	UWorld* World = nullptr;
 	if (bUsePIE)
 	{
+		// 检查 PIE 是否正处于过渡状态（启动/停止中），避免访问不稳定的世界对象
+		if (UPieSessionTool::IsPIETransitioning())
+		{
+			return FMcpToolResult::Error(TEXT("PIE is currently transitioning (starting or stopping). Please wait and try again."));
+		}
+
 		// Find PIE world
 		for (const FWorldContext& WorldContext : GEngine->GetWorldContexts())
 		{

--- a/Source/YesUeMcpEditor/Public/Tools/Build/TriggerLiveCodingTool.h
+++ b/Source/YesUeMcpEditor/Public/Tools/Build/TriggerLiveCodingTool.h
@@ -34,10 +34,10 @@ public:
 
 private:
 #if PLATFORM_WINDOWS
-	// Execute synchronous compilation (blocks until complete)
-	FMcpToolResult ExecuteSynchronous(ILiveCodingModule* LiveCodingModule);
+	// 查询编译状态（非阻塞）
+	FMcpToolResult QueryCompilationStatus(ILiveCodingModule* LiveCodingModule);
 
-	// Execute asynchronous compilation (fire and forget)
+	// 触发异步编译（fire-and-forget）
 	FMcpToolResult ExecuteAsynchronous(ILiveCodingModule* LiveCodingModule);
 #endif
 };

--- a/Source/YesUeMcpEditor/Public/Tools/PIE/PieSessionTool.h
+++ b/Source/YesUeMcpEditor/Public/Tools/PIE/PieSessionTool.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Tools/McpToolBase.h"
+#include "Editor.h"
 #include "PieSessionTool.generated.h"
 
 /**
@@ -25,6 +26,12 @@ public:
 		const FMcpToolContext& Context) override;
 	virtual bool RequiresGameThread() const override { return true; }
 
+	/**
+	 * 检查 PIE 是否正处于过渡状态（正在启动或停止）。
+	 * 其他工具在执行前应检查此状态，避免在 PIE 过渡期间访问正在创建/销毁的世界对象。
+	 */
+	static bool IsPIETransitioning() { return bPIETransitioning; }
+
 private:
 	FMcpToolResult ExecuteStart(const TSharedPtr<FJsonObject>& Arguments);
 	FMcpToolResult ExecuteStop(const TSharedPtr<FJsonObject>& Arguments);
@@ -37,7 +44,18 @@ private:
 	AActor* FindActorByName(UWorld* World, const FString& ActorName) const;
 	TSharedPtr<FJsonValue> GetActorProperty(AActor* Actor, const FString& PropertyName) const;
 	UWorld* GetPIEWorld() const;
-	bool WaitForPIEReady(float TimeoutSeconds) const;
+	bool CompareJsonValues(const TSharedPtr<FJsonValue>& Actual, const TSharedPtr<FJsonValue>& Expected, const FString& Operator) const;
 	TSharedPtr<FJsonObject> GetWorldInfo(UWorld* PIEWorld) const;
 	TArray<TSharedPtr<FJsonValue>> GetPlayersInfo(UWorld* PIEWorld) const;
+
+	/** 注册/注销 PIE 事件回调，用于在 PIE 完成启动或停止后清除过渡标志 */
+	static void RegisterPIECallbacks();
+	static void UnregisterPIECallbacks();
+
+	/** PIE 过渡状态标志：true 表示 PIE 正在启动或停止中 */
+	static bool bPIETransitioning;
+	
+	/** PIE 事件回调的 DelegateHandle */
+	static FDelegateHandle PIEStartedHandle;
+	static FDelegateHandle PIEEndedHandle;
 };


### PR DESCRIPTION
## Summary
Fixed 3 bugs in yes-ue-mcp plugin (tested on UE 5.6 + LyraStarterGame):

### Bug 1: PIE Start/Stop deadlock (PieSessionTool.cpp)
- `ExecuteStart`/`ExecuteStop` blocked on GameThread waiting for PIE state change
- PIE couldn't tick while GameThread was blocked → permanent deadlock, MCP blocked forever
- **Fix**: Fire-and-forget pattern; `RequestPlaySession`/`RequestEndPlayMap` returns immediately with "starting"/"stopping" status, client polls via `get-state`

### Bug 2: Python try-wrapper indent error (RunPythonScriptTool.cpp)
- `Command.Replace("\n", "\n    ")` only indented lines after the first
- First line of user script was not indented inside `try:` block → Python SyntaxError
- **Fix**: Prepend 4-space indent to first line: `FString IndentedCommand = TEXT("    ") + Command.Replace(TEXT("\n"), TEXT("\n    "));`

### Bug 3: Unsafe unconditional GC crash (RunPythonScriptTool.cpp)
- `CollectGarbage()` called unconditionally after every Python execution
- After Python errors, this caused use-after-free crash (Access Violation in `CodepointFromUtf8` — SourceString pointer contained UTF-16 data `0x006c004300640065` misinterpreted as UTF-8)
- **Fix**: Moved `CollectGarbage` out of `ExecutePython()`, only called in `Execute()` when `bLevelLoadDetected == true`

### Files Changed
- `Source/YesUeMcpEditor/Private/Tools/PIE/PieSessionTool.cpp`
- `Source/YesUeMcpEditor/Private/Tools/Scripting/RunPythonScriptTool.cpp`